### PR TITLE
Update envoy_reader.py for 6 month token error

### DIFF
--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -229,6 +229,9 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 'user[password]': self.enlighten_pass,
             }
             resp = await client.post(ENLIGHTEN_AUTH_FORM_URL+form_action, data=payload_login, timeout=10)
+            if resp.status_code == 302:
+                #wait for session to be created
+                time.sleep(.2)
             if resp.status_code >= 400:
                 raise Exception("Could not Authenticate via Enlighten auth form")
 


### PR DESCRIPTION
Took a look at this, there's a 302 in the initial login response and I had thought it was not going through the full logon process - when I was debugging, the login > token generation steps worked flawless every time, but when running, I never generated a session. I tried using allow_redirects in the httpx post, but that did not do it. So here's the hacky fix - add a .2 second delay (this is the shortest, I tried everything else) when we login to enlighten before gathering a token from their web service. If you know of a better way, lets use that instead, but this seems to work reliably.