### PR TITLE
Add grid import and export sensors for use by HA energy dashboard

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                         data[description.key] = battery_dict
 
-                elif (description.key not in ["current_battery_capacity", "total_battery_percentage"]):
+                elif (description.key not in ["current_battery_capacity", "total_battery_percentage", "grid_import", "grid_export"]):
                     data[description.key] = await getattr(
                         envoy_reader, description.key
                     )()

--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -73,6 +73,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     )()
 
             data["grid_status"] = await envoy_reader.grid_status()
+            
+            if "lifetime_consumption" in data and "lifetime_production" in data:
+                LEC_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_lifetime_energy_consumption" )
+                LEP_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_lifetime_energy_production" )
+                TGEI_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_total_grid_energy_imported" )
+                TGEE_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_total_grid_energy_exported" )
+
+                if LEC_state and str(LEC_state.state) != "unknown" and LEP_state and str(LEP_state.state) != "unknown":
+                    LEC_delta = data["lifetime_consumption"] - int(LEC_state.state)
+                    LEP_delta = data["lifetime_production"] - int(LEP_state.state)
+                    data["grid_import"] = 0
+                    data["grid_export"] = 0
+
+                    if LEC_delta < data["lifetime_consumption"] and TGEI_state and str(TGEI_state.state) != "unknown":
+                        data["grid_import"] = max(LEC_delta - LEP_delta, 0) + int(TGEI_state.state)
+
+                    if LEP_delta < data["lifetime_production"] and TGEE_state and str(TGEE_state.state) != "unknown":
+                        data["grid_export"] = max(LEP_delta - LEC_delta, 0) + int(TGEE_state.state)
 
             _LOGGER.debug("Retrieved data from API: %s", data)
 

--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -80,16 +80,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 TGEI_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_total_grid_energy_imported" )
                 TGEE_state = hass.states.get( "sensor.envoy_" + config[CONF_SERIAL] + "_total_grid_energy_exported" )
 
-                if LEC_state and str(LEC_state.state) != "unknown" and LEP_state and str(LEP_state.state) != "unknown":
+                if LEC_state and str(LEC_state.state).isnumeric() and LEP_state and str(LEP_state.state).isnumeric():
                     LEC_delta = data["lifetime_consumption"] - int(LEC_state.state)
                     LEP_delta = data["lifetime_production"] - int(LEP_state.state)
                     data["grid_import"] = 0
                     data["grid_export"] = 0
 
-                    if LEC_delta < data["lifetime_consumption"] and TGEI_state and str(TGEI_state.state) != "unknown":
+                    if LEC_delta < data["lifetime_consumption"] and TGEI_state and str(TGEI_state.state).isnumeric():
                         data["grid_import"] = max(LEC_delta - LEP_delta, 0) + int(TGEI_state.state)
 
-                    if LEP_delta < data["lifetime_production"] and TGEE_state and str(TGEE_state.state) != "unknown":
+                    if LEP_delta < data["lifetime_production"] and TGEE_state and str(TGEE_state.state).isnumeric():
                         data["grid_export"] = max(LEP_delta - LEC_delta, 0) + int(TGEE_state.state)
 
             _LOGGER.debug("Retrieved data from API: %s", data)

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -105,6 +105,20 @@ SENSORS = (
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.ENERGY
     ),
+    SensorEntityDescription(
+        key="grid_import",
+        name="Grid Energy Imported Counter",
+        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+    ),
+    SensorEntityDescription(
+        key="grid_export",
+        name="Grid Energy Exported Counter",
+        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+    ),
 )
 
 BATTERY_ENERGY_DISCHARGED_SENSOR = SensorEntityDescription(

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -107,14 +107,14 @@ SENSORS = (
     ),
     SensorEntityDescription(
         key="grid_import",
-        name="Grid Energy Imported Counter",
+        name="Total Grid Energy Imported",
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(
         key="grid_export",
-        name="Grid Energy Exported Counter",
+        name="Total Grid Energy Exported",
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,


### PR DESCRIPTION
Home assistant's energy dashboard is expecting net energy imported and exported, but this component only gives total energy consumed and produced and is therefore incompatible with this feature.

Using the lifetime energy production and consumption values, we can determine a delta between current and last poll value, and then determine if we imported or exported this amount of energy to/from the grid.

This PR is proof of concept only. I am not a python developer and the method I am using to retrieve the last sensor value is likely not correct (as I believe entity IDs can be changed). I'm hoping you know how to pull the last value from the DataUpdateCoordinator or elsewhere, and replace those four lines.
