### PR TITLE
#45: Replace async_setup_platforms with async_forward_entry_setups

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -105,7 +105,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         NAME: name,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Fixes #45 (when combined with #50) and #49. The old `async_setup_platforms` will be removed with 2023.3, and according to https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/ just replacing it with an awaited `async_forward_entry_setups` should be enough.

Seems to work here, reconfigured my Envoy D7 in HASS after locally applying this change. I am still seeing the data come in, and no more log entries 🎉