### PR TITLE
Envoy reader update to support local IPv6 addresses as (auto-discovered) host [Invalid port fix]

### DIFF
--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -100,6 +100,9 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
     ):
         """Init the EnvoyReader."""
         self.host = host.lower()
+        # IPv6 addresses need to be enclosed in brackets
+        if ":" in self.host and not self.host.startswith("["):
+            self.host = f"[{self.host}]"
         self.username = username
         self.password = password
         self.get_inverters = inverters

--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -11,6 +11,7 @@ from json.decoder import JSONDecodeError
 import httpx
 from bs4 import BeautifulSoup
 from envoy_utils.envoy_utils import EnvoyUtils
+from homeassistant.util.network import is_ipv6_address
 
 #
 # Legacy parser is only used on ancient firmwares
@@ -101,7 +102,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Init the EnvoyReader."""
         self.host = host.lower()
         # IPv6 addresses need to be enclosed in brackets
-        if self.host.count(":") > 1 and not self.host.startswith("["):
+        if is_ipv6_address(self.host):
             self.host = f"[{self.host}]"
         self.username = username
         self.password = password

--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -101,7 +101,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Init the EnvoyReader."""
         self.host = host.lower()
         # IPv6 addresses need to be enclosed in brackets
-        if ":" in self.host and not self.host.startswith("["):
+        if self.host.count(":") > 1 and not self.host.startswith("["):
             self.host = f"[{self.host}]"
         self.username = username
         self.password = password


### PR DESCRIPTION
Today my Envoy stopped working as my Router assigned an ipv6 address to my envoy.

I'm not a Python dev so, I'm not sure if this is the right place for this in Python coding guidelines or so, but with this quickfix my integration went back up.