### PR TITLE
Use ipv4 in zeroconf when core is using ipv4 address

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,3 @@ This is a HACS custom integration for enphase envoys with firmware version 7.X. 
       When configuring the Envoy with firmware 7 or higher specify your Enphase Enlighten username and password, the envoy serial number and check the 'Use Enlighten' box at the bottom. This will allow the integration to collect a token from the enphase website and use it to access the Envoy locally. It does this at first configuration, at each HA startup or at reload of the integration. The Enphase web-site is known to be slow or satured at times. When an *Unknown Error* is reported during configuration try again until success. [#81](https://github.com/briancmpbll/home_assistant_custom_envoy/issues/81) \
       \
       Upon changing your password on the Enphase web site you will have to update the password information in HA. To update it, delete the envoy integration from the Settings / Integrations window. Restart HA and then in Integrations window configure it again. All data is kept and will show again once it's configured.
-
-  - [#75 Invalid Port and IPV6 autodetect](https://github.com/briancmpbll/home_assistant_custom_envoy/issues/75) \
-      HA performs auto discovery for Envoy on the network. When it identifies an Envoy it will use the Envoy serial number 
-      to identify a configured Envoy and then update the IP addres of the Envoy. If the auto discovery returns an IPV6 address it will update the Envoy with reported IPv6 address even if it was configured with an IPv4 address before. This causes the integration to fail as IPv6 addresses cause issues in the communication to the Envoy. \
-      \
-      To solve this and prevent this from happening again, remove the Envoy in the Integrations panel, restart HA and configure the Envoy again with the IPv4 address. This may require to change the IP address to the IPv4 on the auto detected Envoy or add manually an Envoy Integration. \
-      \
-      Then open the *System options* on the Envoy Integrations menu (3 vertical dots). In the System options panel de-activate the *Enable Newly Added Entities* option to turn it off. This will cause the Envoy Intgeration to ignore autodetect updates and keep the configured IP address. Make sure the Envoy is using a fixed IP address to avoid loosing connection if it changes its IP.

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -54,7 +54,7 @@ async def ipv4asdefault(hass: HomeAssistant):
     for adapter in adapters:
         if adapter["default"]:
             return adapter["ipv4"] is not None
-    return True
+    return False
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Enphase Envoy."""

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -63,7 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _async_generate_schema(self):
         """Generate schema."""
         schema = {}
-
+        _LOGGER.debug("_async_generate_schema")
         if self.ip_address:
             schema[vol.Required(CONF_HOST, default=self.ip_address)] = vol.In(
                 [self.ip_address]
@@ -80,6 +80,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def _async_current_hosts(self):
         """Return a set of hosts."""
+        _LOGGER.debug("_async_current_hosts")
         return {
             entry.data[CONF_HOST]
             for entry in self._async_current_entries(include_ignore=False)
@@ -90,11 +91,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
+        _LOGGER.debug("async_step_zeroconf")
         serial = discovery_info.properties["serialnum"]
         await self.async_set_unique_id(serial)
 
         #75 If system option to enable newly discoverd entries is off (by user) and uniqueid is this serial then skip updating ip
         for entry in self._async_current_entries(include_ignore=False):
+            _LOGGER.debug("entry: %s",entry.data)
             if entry.pref_disable_new_entities and entry.unique_id is not None:
                 if entry.unique_id == serial:
                     _LOGGER.debug("Envoy autodiscovery/ip update disabled for: %s, IP detected: %s %s",serial, discovery_info.host,entry.unique_id)
@@ -122,6 +125,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, user_input):
         """Handle configuration by re-auth."""
+        _LOGGER.debug("async_step_reauth")
         self._reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
@@ -129,6 +133,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _async_envoy_name(self) -> str:
         """Return the name of the envoy."""
+        _LOGGER.debug("_async_envoy_name")
         if self.unique_id:
             return f"{ENVOY} {self.unique_id}"
         return ENVOY
@@ -136,6 +141,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_set_unique_id_from_envoy(self, envoy_reader: EnvoyReader) -> bool:
         """Set the unique id by fetching it from the envoy."""
         serial = None
+        _LOGGER.debug("_async_set_unique_id_from_envoy")
         with contextlib.suppress(httpx.HTTPError):
             serial = await envoy_reader.get_full_serial_number()
         if serial:
@@ -148,7 +154,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-
+        _LOGGER.debug("async_step_user")
         if user_input is not None:
             if (
                 not self._reauth_entry

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNA
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util.network import is_ipv4_address
 
 from .const import DOMAIN, CONF_SERIAL, CONF_USE_ENLIGHTEN, DEFAULT_SCAN_INTERVAL
 
@@ -48,6 +49,12 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> EnvoyRead
 
     return envoy_reader
 
+async def ipv4asdefault(hass: HomeAssistant):
+    adapters = await network.async_get_adapters(hass)
+    for adapter in adapters:
+        if adapter["default"]:
+            return adapter["ipv4"] is not None
+    return True
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Enphase Envoy."""
@@ -94,21 +101,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         serial = discovery_info.properties["serialnum"]
         await self.async_set_unique_id(serial)
 
-        adapters = await network.async_get_adapters()
+        ipv4_default = await ipv4asdefault(self.hass)
 
-        for adapter in adapters:
-            _LOGGER.exception(adapter.default)
-            for ip_info in adapter["ipv4"]:
-                _LOGGER.exception(ip_info["address"])
-            for ip6_info in adapter["ipv6"]:
-                _LOGGER.exception(ip6_info["address"])
-
-        #75 If system option to enable newly discoverd entries is off (by user) and uniqueid is this serial then skip updating ip
-        for entry in self._async_current_entries(include_ignore=False):
-            if entry.pref_disable_new_entities and entry.unique_id is not None:
-                if entry.unique_id == serial:
-                    _LOGGER.debug("Envoy autodiscovery/ip update disabled for: %s, IP detected: %s %s",serial, discovery_info.host,entry.unique_id)
-                    return self.async_abort(reason="pref_disable_new_entities")
+        if ipv4_default and not is_ipv4_address(discovery_info.host):
+            return self.async_abort(reason="not_ipv4_address")
                 
         # autodiscovery is updating the ip address of an existing envoy with matching serial to new detected ip adress
         self.ip_address = discovery_info.host

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -104,6 +104,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="pref_disable_new_entities")
                 
         # autodiscovery is updating the ip address of an existing envoy with matching serial to new detected ip adress
+        for disc in discovery_info.properties:
+            _LOGGER.debug(disc)
+
         self.ip_address = discovery_info.host
         self._abort_if_unique_id_configured({CONF_HOST: self.ip_address})
         for entry in self._async_current_entries(include_ignore=False):

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -10,6 +10,7 @@ import httpx
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components import network
 from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
@@ -92,6 +93,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by zeroconf discovery."""
         serial = discovery_info.properties["serialnum"]
         await self.async_set_unique_id(serial)
+
+        adapters = await network.async_get_adapters()
+
+        for adapter in adapters:
+            for ip_info in adapter["ipv4"]:
+                local_ip = ip_info["address"]
+                network_prefix = ip_info["network_prefix"]
+                ip_net = ip_network(f"{local_ip}/{network_prefix}", False)
 
         #75 If system option to enable newly discoverd entries is off (by user) and uniqueid is this serial then skip updating ip
         for entry in self._async_current_entries(include_ignore=False):

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -97,10 +97,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         adapters = await network.async_get_adapters()
 
         for adapter in adapters:
+            _LOGGER.exception(adapter.default)
             for ip_info in adapter["ipv4"]:
-                local_ip = ip_info["address"]
-                network_prefix = ip_info["network_prefix"]
-                ip_net = ip_network(f"{local_ip}/{network_prefix}", False)
+                _LOGGER.exception(ip_info["address"])
+            for ip6_info in adapter["ipv6"]:
+                _LOGGER.exception(ip6_info["address"])
 
         #75 If system option to enable newly discoverd entries is off (by user) and uniqueid is this serial then skip updating ip
         for entry in self._async_current_entries(include_ignore=False):

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -63,7 +63,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _async_generate_schema(self):
         """Generate schema."""
         schema = {}
-        _LOGGER.debug("_async_generate_schema")
+
         if self.ip_address:
             schema[vol.Required(CONF_HOST, default=self.ip_address)] = vol.In(
                 [self.ip_address]
@@ -80,7 +80,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def _async_current_hosts(self):
         """Return a set of hosts."""
-        _LOGGER.debug("_async_current_hosts")
         return {
             entry.data[CONF_HOST]
             for entry in self._async_current_entries(include_ignore=False)
@@ -91,21 +90,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
-        _LOGGER.debug("async_step_zeroconf")
         serial = discovery_info.properties["serialnum"]
         await self.async_set_unique_id(serial)
 
         #75 If system option to enable newly discoverd entries is off (by user) and uniqueid is this serial then skip updating ip
         for entry in self._async_current_entries(include_ignore=False):
-            _LOGGER.debug("entry: %s",entry.data)
             if entry.pref_disable_new_entities and entry.unique_id is not None:
                 if entry.unique_id == serial:
                     _LOGGER.debug("Envoy autodiscovery/ip update disabled for: %s, IP detected: %s %s",serial, discovery_info.host,entry.unique_id)
                     return self.async_abort(reason="pref_disable_new_entities")
                 
         # autodiscovery is updating the ip address of an existing envoy with matching serial to new detected ip adress
-        _LOGGER.debug(discovery_info)
-
         self.ip_address = discovery_info.host
         self._abort_if_unique_id_configured({CONF_HOST: self.ip_address})
         for entry in self._async_current_entries(include_ignore=False):
@@ -127,7 +122,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, user_input):
         """Handle configuration by re-auth."""
-        _LOGGER.debug("async_step_reauth")
         self._reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
@@ -135,7 +129,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _async_envoy_name(self) -> str:
         """Return the name of the envoy."""
-        _LOGGER.debug("_async_envoy_name")
         if self.unique_id:
             return f"{ENVOY} {self.unique_id}"
         return ENVOY
@@ -143,7 +136,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_set_unique_id_from_envoy(self, envoy_reader: EnvoyReader) -> bool:
         """Set the unique id by fetching it from the envoy."""
         serial = None
-        _LOGGER.debug("_async_set_unique_id_from_envoy")
         with contextlib.suppress(httpx.HTTPError):
             serial = await envoy_reader.get_full_serial_number()
         if serial:
@@ -156,7 +148,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-        _LOGGER.debug("async_step_user")
+
         if user_input is not None:
             if (
                 not self._reauth_entry

--- a/custom_components/enphase_envoy_custom/config_flow.py
+++ b/custom_components/enphase_envoy_custom/config_flow.py
@@ -104,8 +104,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="pref_disable_new_entities")
                 
         # autodiscovery is updating the ip address of an existing envoy with matching serial to new detected ip adress
-        for disc in discovery_info.properties:
-            _LOGGER.debug(disc)
+        _LOGGER.debug(discovery_info)
 
         self.ip_address = discovery_info.host
         self._abort_if_unique_id_configured({CONF_HOST: self.ip_address})

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -47,7 +47,7 @@ SENSORS = (
         key="seven_days_production",
         name="Last Seven Days Energy Production",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
+        state_class=SensorStateClass.TOTAL,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
Currently the integration will autodetect an ipv6 address through zeroconf, even when the network is not configured for ipv6. Reasons: in homeassistant the main interface contains an ipv6 address even if you disable ipv6 through the Gui. Also the enphase envoy does expose an ipv6 address for autodiscovery; this cannot be disabled.

In order to have ipv4-only networks autodetect the correct ip, the zeroconf routine checks for an existing ipv4 address on the main interface of home assistant. If it finds one; the ipv6 detection is skipped so it correctly autodiscovers the ipv4 address, If homeassistant is configured to use ipv6 only, the ipv6 address will be autodiscovered.