### PR TITLE
Do not collect inverters for legacy model

### DIFF
--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -461,6 +461,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             and self.endpoint_production_results.status_code == 200
         ):
             self.endpoint_type = ENVOY_MODEL_LEGACY  # older Envoy-C
+            self.get_inverters = False # don't get inverters for this model
             return
 
         raise RuntimeError(


### PR DESCRIPTION
Changes made in 0.0.12 to add support for 3 phase revealed that legacy model code was trying to get inverter data which is not available. Logic to not collect inverter data was present but not switched on in case of legacy envoy. Changed to activate that logic in case of legacy models.