### PR TITLE
Add some debug and warning to find ENVOY R issues

### DIFF
--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -185,9 +185,10 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Retry 3 times to fetch the url if there is a transport error."""
         for attempt in range(3):
             _LOGGER.debug(
-                "HTTP GET Attempt #%s: %s: Header:%s",
+                "HTTP GET Attempt #%s: %s: %s: Header:%s",
                 attempt + 1,
                 url,
+                self.use_enlighten_owner_token,
                 self._authorization_header,
             )
             try:
@@ -195,22 +196,29 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                     resp = await client.get(
                         url, headers=self._authorization_header, timeout=30, **kwargs
                     )
-                    if resp.status_code == 401 and attempt < 2 and self.use_enlighten_owner_token:
-                        _LOGGER.debug(
-                            "Received 401 from Envoy; refreshing token, attempt %s of 2",
-                            attempt+1,
+                    if resp.status_code == 401 and attempt < 2:
+                        if self.use_enlighten_owner_token:
+                            _LOGGER.warning(
+                                "Debug Info:Received 401 from Envoy; refreshing token, attempt %s of 2: %s: %s: Header:%s",
+                                attempt+1,
+                                url,
+                                self.use_enlighten_owner_token,
+                                self._authorization_header,
+                             )
+                            could_refresh_cookies = await self._refresh_token_cookies()
+                            if not could_refresh_cookies:
+                                await self._getEnphaseToken()
+                            continue
+                        # don't try token and cookies refresh for legacy envoy
+                        else:
+                            _LOGGER.warning(
+                                "Debug Info:Received 401 from Envoy; retrying, attempt %s of 2: %s: %s: Header:%s",
+                                attempt+1,
+                                url,
+                                self.use_enlighten_owner_token,
+                                self._authorization_header,
                             )
-                        could_refresh_cookies = await self._refresh_token_cookies()
-                        if not could_refresh_cookies:
-                            await self._getEnphaseToken()
-                        continue
-                    # don't try token and cookies refresh for legacy envoy
-                    elif resp.status_code == 401 and attempt < 2:
-                        _LOGGER.debug(
-                            "Received 401 from Envoy; retrying, attempt %s of 2",
-                            attempt+1,
-                            )
-                        continue
+                            continue
                     _LOGGER.debug("Fetched from %s: %s: %s", url, resp, resp.text)
                     if resp.status_code == 404:
                         return None
@@ -318,6 +326,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """
         # Create HTTP Header
         self._authorization_header = {"Authorization": "Bearer " + self._token}
+        _LOGGER.warning("Debug Info: setting Authorization header with token.")
 
         # Fetch the Enphase Token status from the local Envoy
         token_validation_html = await self._async_fetch_with_retry(
@@ -413,7 +422,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         if response.status_code == 401:
             if self.endpoint_type in [ENVOY_MODEL_C, ENVOY_MODEL_LEGACY]:
                 self.get_inverters = False
-                _LOGGER.warning("Error 401 for getting invertors, disabling inverters collection")
+                _LOGGER.warning("Getdata Error 401 for getting invertors, disabling inverters collection")
             response.raise_for_status()
         self.endpoint_production_inverters = response
         return
@@ -467,6 +476,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             and self.endpoint_production_v1_results.status_code == 200
         ):
             self.endpoint_type = ENVOY_MODEL_C  # Envoy-C, production only
+            _LOGGER.warning("Debug Info: Envoy identified as %s",self.endpoint_type)
             return
 
         try:
@@ -479,6 +489,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         ):
             self.endpoint_type = ENVOY_MODEL_LEGACY  # older Envoy-C
             self.get_inverters = False # don't get inverters for this model
+            _LOGGER.warning("Debug Info: Envoy identified as %s",self.endpoint_type)
             return
 
         raise RuntimeError(
@@ -511,6 +522,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         match = SERIAL_REGEX.search(response.text)
         if match:
             # if info.xml is in html format we're dealing with ENVOY R
+            _LOGGER.warning("Debug Info:Legacy model as determined by info.xml being html. Disabling inverters")
             self.get_inverters = False
             return match.group(1)
 


### PR DESCRIPTION
ENVOY R with FW >= R3.9 Has v1/production but doesn't use tokens nor has it inverters.json for which it gets 401. Current code is reacting to set token cookies but no token is available and invalid header gets reported. This versions add some warnings to be able to trace it's decision path and not get tokens if use enlighten is not set.