### PR TITLE
Add diagnostics download option for Envoy device

### DIFF
--- a/custom_components/enphase_envoy_custom/diagnostics.py
+++ b/custom_components/enphase_envoy_custom/diagnostics.py
@@ -1,0 +1,71 @@
+"""Diagnostics support for Enphase Envoy."""
+from __future__ import annotations
+
+from typing import Any
+
+from attr import asdict
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import COORDINATOR, DOMAIN
+
+CONF_TITLE = "title"
+
+TO_REDACT = {
+    # CONF_NAME,
+    CONF_PASSWORD,
+    # Config entry title and unique ID may contain sensitive data:
+    # CONF_TITLE,
+    # CONF_UNIQUE_ID,
+    CONF_USERNAME,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    devices = []
+
+    registry_devices = dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    )
+
+    for device in registry_devices:
+        entities = []
+
+        registry_entities = er.async_entries_for_device(
+            entity_registry,
+            device_id=device.id,
+            include_disabled_entities=True,
+        )
+
+        for entity in registry_entities:
+            state_dict = None
+            if state := hass.states.get(entity.entity_id):
+                state_dict = dict(state.as_dict())
+                state_dict.pop("context", None)
+
+            entities.append({"entry": asdict(entity), "state": state_dict})
+
+        devices.append({"device": asdict(device), "entities": entities})
+
+    return async_redact_data(
+        {
+            "entry": entry.as_dict(),
+            "data": coordinator.data,
+            "Note": "Entities that show as null are not available for your Envoy",
+            "devices": devices,
+        },
+        TO_REDACT,
+    )


### PR DESCRIPTION
Add diagnostics.py to enable the Download Diagnostics for Envoy Device. It will download intgeration information and HA entity information used by the Envoy to assist with troubleshooting.