### PR TITLE
Replace use of Enlighten form by login.json site

### DIFF
--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -9,7 +9,7 @@ import time
 from json.decoder import JSONDecodeError
 
 import httpx
-from bs4 import BeautifulSoup
+import xmltodict
 from envoy_utils.envoy_utils import EnvoyUtils
 from homeassistant.util.network import is_ipv6_address
 
@@ -43,9 +43,9 @@ ENVOY_MODEL_LEGACY = "P0"
 LOGIN_URL = "https://entrez.enphaseenergy.com/login_main_page"
 TOKEN_URL = "https://entrez.enphaseenergy.com/entrez_tokens"
 
-# paths for the enlighten 6 month owner token
-ENLIGHTEN_AUTH_FORM_URL = "https://enlighten.enphaseenergy.com"
-ENLIGHTEN_TOKEN_URL = "https://enlighten.enphaseenergy.com/entrez-auth-token?serial_num={}"
+# paths for the enlighten 1 year owner token
+ENLIGHTEN_AUTH_URL = "https://enlighten.enphaseenergy.com/login/login.json"
+ENLIGHTEN_TOKEN_URL = "https://entrez.enphaseenergy.com/tokens"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                                 self._authorization_header,
                             )
                             continue
-                    _LOGGER.debug("Fetched from %s: %s: %s", url, resp, resp.text)
+                    _LOGGER.debug("Fetched (%s) from %s: %s: %s",  attempt + 1, url, resp, resp.text)
                     if resp.status_code == 404:
                         return None
                     return resp
@@ -227,7 +227,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 if attempt == 2:
                     raise
 
-    async def _async_post(self, url, data, cookies=None, **kwargs):
+    async def _async_post(self, url, data=None, cookies=None, **kwargs):
         _LOGGER.debug("HTTP POST Attempt: %s", url)
         # _LOGGER.debug("HTTP POST Data: %s", data)
         try:
@@ -242,80 +242,37 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             raise
 
     async def _fetch_owner_token_json(self) :
-        """
-        Try to fetch the owner token json from Enlighten API
-        :return:
-        """
+        """Try to fetch the owner token json from Enlighten API"""
         async with self.async_client as client:
-            # login to the enlighten UI
-
-            resp = await client.get(ENLIGHTEN_AUTH_FORM_URL)
-            soup = BeautifulSoup(resp.text, features="html.parser")
-            # grab the single use auth token for this form
-            authenticity_token = soup.find('input', {'name': 'authenticity_token'})["value"]
-            # and the form action itself
-            form_action = soup.find('input', {'name': 'authenticity_token'}).parent["action"]
+            # login to the enlighten website
             payload_login = {
-                'authenticity_token': authenticity_token,
                 'user[email]': self.enlighten_user,
                 'user[password]': self.enlighten_pass,
             }
-            resp = await client.post(ENLIGHTEN_AUTH_FORM_URL+form_action, data=payload_login, timeout=10)
+            resp = await client.post(ENLIGHTEN_AUTH_URL, data=payload_login, timeout=30)
             if resp.status_code >= 400:
-                raise Exception("Could not Authenticate via Enlighten auth form")
+                raise RuntimeError("Could not Authenticate via Enlighten")
 
-            # now that we're in a logged in session, we can request the 6 month owner token via enlighten
-            resp = await client.get(ENLIGHTEN_TOKEN_URL.format(self.enlighten_serial_num))
-            resp_json = resp.json()
-            if "token" not in resp_json.keys():
-                msg = resp_json.get("message", "Unknown error returned from enlighten: " + resp.text)
-                raise Exception("Could not get 6 month token: " + msg)
-            return resp_json
-
-    async def _getEnphaseToken(  # pylint: disable=invalid-name
-        self,
-    ):
-        payload_login = {
-            "username": self.enlighten_user,
-            "password": self.enlighten_pass,
-        }
-
-        if self.use_enlighten_owner_token:
-            token_json = await self._fetch_owner_token_json()
-
-            self._token = token_json["token"]
-            time_left_days = (token_json["expires_at"] - time.time())/(24*3600)
-            _LOGGER.debug("Commissioned Token valid for %s days", time_left_days)
-
-        elif self.commissioned == "True" or self.commissioned == "Commissioned":
-            # Login to website and store cookie
-            resp = await self._async_post(LOGIN_URL, data=payload_login)
+            # now that we're in a logged in session, we can request the 1 year owner token via enlighten
+            login_data = resp.json()
             payload_token = {
-                "Site": self.enlighten_site_id,
-                "serialNum": self.enlighten_serial_num,
+                "session_id": login_data["session_id"],
+                "serial_num": self.enlighten_serial_num,
+                "username": self.enlighten_user,
             }
-            response = await self._async_post(
-                TOKEN_URL, data=payload_token, cookies=resp.cookies
+            resp = await client.post(
+                ENLIGHTEN_TOKEN_URL, json=payload_token, timeout=30
             )
+            if resp.status_code != 200:
+                raise RuntimeError("Could not get enlighten token")
+            return resp.text
 
-            parsed_html = BeautifulSoup(response.text, features="html.parser")
-            self._token = parsed_html.body.find(  # pylint: disable=invalid-name, unused-variable, redefined-outer-name
-                "textarea"
-            ).text
-            _LOGGER.debug("Commissioned Token: %s", self._token)
+    async def _getEnphaseToken(self):
+        self._token = await self._fetch_owner_token_json()
+        _LOGGER.debug("Obtained Token")
 
-        else:
-            # Login to website and store cookie
-            resp = await self._async_post(LOGIN_URL, data=payload_login)
-            payload_token = {"uncommissioned": "true", "Site": ""}
-            response = await self._async_post(
-                TOKEN_URL, data=payload_token, cookies=resp.cookies
-            )
-            soup = BeautifulSoup(response.text, features="html.parser")
-            self._token = soup.find("textarea").contents[
-                0
-            ]  # pylint: disable=invalid-name
-            _LOGGER.debug("Uncommissioned Token: %s", self._token)
+        if self._is_enphase_token_expired(self._token):
+            raise RuntimeError("Just received token already expired")
 
         await self._refresh_token_cookies()
 
@@ -329,16 +286,13 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         _LOGGER.warning("Debug Info: setting Authorization header with token.")
 
         # Fetch the Enphase Token status from the local Envoy
-        token_validation_html = await self._async_fetch_with_retry(
+        token_validation = await self._async_fetch_with_retry(
             ENDPOINT_URL_CHECK_JWT.format(self.host)
         )
 
-        # Parse the HTML return from Envoy and check the text
-        soup = BeautifulSoup(token_validation_html.text, features="html.parser")
-        token_validation = soup.find("h2").contents[0]
-        if self._is_enphase_token_valid(token_validation) :
+        if token_validation.status_code == 200:
             # set the cookies for future clients
-            self._cookies = token_validation_html.cookies
+            self._cookies = token_validation.cookies
             return True
 
         # token not valid if we get here


### PR DESCRIPTION
Remove use of Enlighten html forms but use login.json site
As done by @vincentwolsink and migrate here.