### PR TITLE
Show FW on device and in diagnostics

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -100,6 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     ] = await envoy_reader.lifetime_consumption_phase(description.key)
                     
             data["grid_status"] = await envoy_reader.grid_status()
+            data["envoy_info"] = await envoy_reader.envoy_info()
 
             _LOGGER.debug("Retrieved data from API: %s", data)
 

--- a/custom_components/enphase_envoy_custom/sensor.py
+++ b/custom_components/enphase_envoy_custom/sensor.py
@@ -189,11 +189,21 @@ class EnvoyEntity(SensorEntity):
         """Return the device_info of the device."""
         if not self._device_serial_number:
             return None
+
+        sw_version = None
+        hw_version = None
+
+        if self.coordinator.data.get("envoy_info"):
+            sw_version = self.coordinator.data.get("envoy_info").get("software", None)
+            hw_version = self.coordinator.data.get("envoy_info").get("pn", None)
+
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._device_serial_number))},
             manufacturer="Enphase",
             model="Envoy",
             name=self._device_name,
+            sw_version=sw_version,
+            hw_version=hw_version,
         )
 
 class CoordinatedEnvoyEntity(EnvoyEntity, CoordinatorEntity):


### PR DESCRIPTION
Obtain FW version from /info page and display in device info 

Add envoy_info to collect this data as well as some internal information and also use for diagnostics purpose

This PR is the last one from the changes made in the [Envoy-2-CORE work](https://github.com/catsmanac/Envoy_2_Core_custom_test) that was [ended](https://github.com/home-assistant/core/issues/88983) by HA adoption a different module to upgrade HA Core Enphase Envoy.

If needed I can provide all changes in a single PR.