### PR TITLE
Fix for #164, get lifetime net production and consumption from ivp/meters/readings

### DIFF
--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -66,7 +66,7 @@ SENSORS = (
         key="lifetime_net_production",
         name="Lifetime Net Energy Production",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(
@@ -204,7 +204,7 @@ PHASE_SENSORS = (
         key="lifetime_net_production_l1",
         name="Lifetime Net Energy Production L1",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(
@@ -231,7 +231,7 @@ PHASE_SENSORS = (
         key="lifetime_net_production_l2",
         name="Lifetime Net Energy Production L2",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(
@@ -258,7 +258,7 @@ PHASE_SENSORS = (
         key="lifetime_net_production_l3",
         name="Lifetime Net Energy Production L3",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
     ),
     SensorEntityDescription(

--- a/custom_components/enphase_envoy_custom/envoy_reader.py
+++ b/custom_components/enphase_envoy_custom/envoy_reader.py
@@ -1166,6 +1166,10 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             device_data["Endpoint-meters"] = self.endpoint_meters_json_results.text
         else:
             device_data["Endpoint-meters"] = self.endpoint_meters_json_results
+        if self.endpoint_meters_readings_json_results:
+            device_data["Endpoint-meters-readings"] = self.endpoint_meters_readings_json_results.text
+        else:
+            device_data["Endpoint-meters-readings"] = self.endpoint_meters_readings_json_results
         if self.endpoint_meters_reports_json_results:
             device_data["Endpoint-meters-reports"] = self.endpoint_meters_reports_json_results.text
         else:
@@ -1245,8 +1249,8 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                     self.pf(),
                     self.voltage(),
                     self.frequency(),
-                    self.current_consumption(),
-                    self.current_production(),
+                    self.consumption_Current(),
+                    self.production_Current(),
                     #get values for phase L2
                     self.production_phase("l2"),
                     self.consumption("l2"),
@@ -1260,8 +1264,8 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                     self.pf("l2"),
                     self.voltage("l2"),
                     self.frequency("l2"),
-                    self.current_consumption("l2"),
-                    self.current_production("l2"),
+                    self.consumption_Current("l2"),
+                    self.production_Current("l2"),
                     return_exceptions=False,
                 )
             )
@@ -1282,8 +1286,8 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             print(f"pf:                       {results[14]}")
             print(f"voltage:                  {results[15]}")
             print(f"frequency:                {results[16]}")
-            print(f"current_consumption:      {results[17]}")
-            print(f"current_production:       {results[18]}")
+            print(f"consumption_Current:      {results[17]}")
+            print(f"production_Current:       {results[18]}")
             print("--Phase L2 values--")
             print(f"production:               {results[19]}")
             print(f"consumption:              {results[20]}")
@@ -1297,8 +1301,8 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             print(f"pf:                       {results[28]}")
             print(f"voltage:                  {results[29]}")
             print(f"frequency:                {results[30]}")
-            print(f"current_consumption:      {results[31]}")
-            print(f"current_production:       {results[32]}")
+            print(f"consumption_Current:      {results[31]}")
+            print(f"production_Current:       {results[32]}")
             if "401" in str(data_results):
                 print(
                     "inverters_production:    Unable to retrieve inverter data - Authentication failure"

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enphase_envoy",
-  "name": "Enphase Envoy (DEV)",
+  "name": "Enphase Envoy (DEV-TEST)",
   "documentation": "https://github.com/briancmpbll/home_assistant_custom_envoy#readme",
   "requirements": [
     "pyjwt",
@@ -11,5 +11,5 @@
   "codeowners": ["@briancmpbll"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.0.18"
+  "version": "0.0.19-BETA-1"
 }

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enphase_envoy",
-  "name": "Enphase Envoy (DEV-TEST)",
+  "name": "Enphase Envoy (DEV)",
   "documentation": "https://github.com/briancmpbll/home_assistant_custom_envoy#readme",
   "requirements": [
     "pyjwt",
@@ -11,5 +11,5 @@
   "codeowners": ["@briancmpbll"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.0.19-BETA-1"
+  "version": "0.0.19"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Enphase Envoy (DEV)",
+  "name": "Enphase Envoy (DEV-TEST)",
   "render_readme": true,
   "content_in_root": false
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Enphase Envoy (DEV-TEST)",
+  "name": "Enphase Envoy (DEV)",
   "render_readme": true,
   "content_in_root": false
 }


### PR DESCRIPTION
FW D7.6.175 reports in ivp/meters/reports lifetime net production (to grid) as negative net consumption (from grid) which is a change from older firmware that reports both a positive running numbers just like ivp/meters/readingsstill does. Switched to using ivp/meters/readings for lifetime net production and consumption so these can be used with HOA Energy dashboard.