### PR TITLE
Add active inverter count for legacy Envoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This integration supports various models but as models have different features t
 
 ## ENVOY C / R / LCD
 
-- Current power production, today's, last 7 days and lifetime energy production.
+- Current power production, today's, last 7 days and lifetime energy production. And Active inverter count, which is disabled by default.
 
 ## IQ Gateway / ENVOY S standard (non metered)
 
@@ -159,6 +159,7 @@ A device `Envoy <serialnumber>` is created with sensor entities for accessible d
 |Envoy \<sn\> Frequency|sensor.Envoy_\<sn\>_frequency|Wh|4,9|
 |Envoy \<sn\> Consumption Current|sensor.Envoy_\<sn\>_consumption_Current|A|4,9|
 |Envoy \<sn\> Production Current|sensor.Envoy_\<sn\>_production_Current|A|4,9|
+|Envoy \<sn\> Active Inverter Count|sensor.Envoy_\<sn\>_active_inverter_count||9,10|
 ||||
 |Grid Status |binary_sensor.grid_status|On/Off|3|
 ||||
@@ -188,7 +189,8 @@ A device `Envoy <serialnumber>` is created with sensor entities for accessible d
 6 Reportedly always zero on Envoy metered with Firmware D8.  
 7 In V0.0.18 renamed to Lifetime Net Energy Consumption /Production from Export Index/Import Import in v0.0.17. Old Entities will show as unavailable.  
 8 Only when consumption CT is installed in 'Load with Solar' mode. In 'Load only' mode values have no meaning.  
-9 Disabled by default and must be enabled in the entities configuration screen. These are values from the consumption CT.
+9 Disabled by default and must be enabled in the entities configuration screen. These are values from the consumption CT.  
+10 Only available on legacy Envoy.
 
 ## Inverter Sensors
 

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -177,6 +177,7 @@ SENSORS = (
         key="active_inverter_count",
         name="Active Inverter Count",
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
     ),
 
 )

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -171,7 +171,7 @@ SENSORS = (
     ),
     SensorEntityDescription(
         key="active_inverter_count",
-        name="Active Inverter Count"
+        name="Active Inverter Count",
         state_class=SensorStateClass.MEASUREMENT,
     ),
 

--- a/custom_components/enphase_envoy_custom/const.py
+++ b/custom_components/enphase_envoy_custom/const.py
@@ -169,6 +169,12 @@ SENSORS = (
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
     ),
+    SensorEntityDescription(
+        key="active_inverter_count",
+        name="Active Inverter Count"
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+
 )
 
 BINARY_SENSORS = (

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enphase_envoy",
-  "name": "Enphase Envoy (DEV-Test)",
+  "name": "Enphase Envoy (DEV)",
   "documentation": "https://github.com/briancmpbll/home_assistant_custom_envoy#readme",
   "requirements": [
     "pyjwt",

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "enphase_envoy",
-  "name": "Enphase Envoy (DEV)",
+  "name": "Enphase Envoy (DEV-Test)",
   "documentation": "https://github.com/briancmpbll/home_assistant_custom_envoy#readme",
   "requirements": [
     "pyjwt",
@@ -11,5 +11,5 @@
   "codeowners": ["@briancmpbll"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.0.19"
+  "version": "0.0.20-Dev-1"
 }

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -11,5 +11,5 @@
   "codeowners": ["@briancmpbll"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.0.20-Dev-1"
+  "version": "0.0.20-Dev-2"
 }

--- a/custom_components/enphase_envoy_custom/manifest.json
+++ b/custom_components/enphase_envoy_custom/manifest.json
@@ -11,5 +11,5 @@
   "codeowners": ["@briancmpbll"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "version": "0.0.20-Dev-2"
+  "version": "0.0.20"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Enphase Envoy (DEV-Test)",
+  "name": "Enphase Envoy (DEV)",
   "render_readme": true,
   "content_in_root": false
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "Enphase Envoy (DEV)",
+  "name": "Enphase Envoy (DEV-Test)",
   "render_readme": true,
   "content_in_root": false
 }


### PR DESCRIPTION
For legacy Envoy collect Active Inverter Count. Entity is disabled by default.